### PR TITLE
Use the git duet co-author feature

### DIFF
--- a/dotfiles/bash_profile
+++ b/dotfiles/bash_profile
@@ -6,6 +6,7 @@ export HISTCONTROL='ignoredups'
 shopt -s histappend
 export GIT_DUET_GLOBAL=true
 export GIT_DUET_ROTATE_AUTHOR=1
+export GIT_DUET_CO_AUTHORED_BY=1
 export BOSH_USE_GEMFILE=1
 export GEM_HOME=~/.gems
 
@@ -105,6 +106,19 @@ alias gst="git status"
 #use this if you need to run lpass from an ssh connection
 alias lpass-ssh='export LPASS_DISABLE_PINENTRY=1; lpass'
 alias gardenwindows=what
+
+function setup_git_duet_hooks() {
+  [ "\$1" == "-h" ] && echo "Ensures duet git hooks are properly configured in a repo that may already have git hooks." && return
+
+  [ -d .git ] || (echo "Not in a git repository" && return)
+
+  git duet
+  git init
+  grep -q duet-prepare-commit-msg .git/hooks/prepare-commit-msg || \
+    echo 'exec git duet-prepare-commit-msg "$@"' >> .git/hooks/prepare-commit-msg
+  grep -q duet-post-commit .git/hooks/post-commit || \
+    echo 'exec git duet-post-commit "$@"' >> .git/hooks/post-commit
+}
 
 gv () {
   [ "$1" == "-h" ] && echo "Vim (windows mode)" && return

--- a/dotfiles/gitconfig.shared
+++ b/dotfiles/gitconfig.shared
@@ -7,7 +7,7 @@
   co = checkout
   br = branch
   d = diff --submodule=log
-  ci = duet-commit
+  ci = commit -v
   su = submodule update --init --recursive
   prb = pull --rebase
   l = log --graph --decorate=short


### PR DESCRIPTION
- see https://github.com/git-duet/git-duet#co-authored-by-trailer-support
- the setup_git_duet_hooks function will correctly set up git duet hooks
in a repo that has preexisting git hooks
- be sure to update git-duet

Co-authored-by: Yechiel Kalmenson <ykalmenson@pivotal.io>
Co-authored-by: Sunjay Bhatia <sbhatia@pivotal.io>