### PR TITLE
test-hwc: invoke ginkgo using go.mod version

### DIFF
--- a/tasks/test-hwc/run.ps1
+++ b/tasks/test-hwc/run.ps1
@@ -1,6 +1,7 @@
 ﻿$ErrorActionPreference = "Stop";
 trap { $host.SetShouldExit(1) }
 
+Write-Host "Installing Windows Dependencies"
 Install-WindowsFeature Web-WHC
 Install-WindowsFeature Web-Webserver
 Install-WindowsFeature Web-WebSockets
@@ -10,14 +11,8 @@ Install-WindowsFeature Web-ASP-Net45
 
 cd hwc
 
-Write-Host "Installing Ginkgo"
-go.exe install -u github.com/onsi/ginkgo/v2/ginkgo@latest
-go.exe get -u github.com/onsi/gomega/...
-if ($LastExitCode -ne 0) {
-    throw "Ginkgo installation process returned error code: $LastExitCode"
-}
-
-ginkgo.exe -r -race -keepGoing -p
+Write-Host "Running Ginkgo Tests"
+go.exe run github.com/onsi/ginkgo/v2/ginkgo -p -r -race -keep-going
 if ($LastExitCode -ne 0) {
     throw "Testing hwc returned error code: $LastExitCode"
 }


### PR DESCRIPTION
This commit changes how ginkgo is invoked to test the hwc repo by using the version defined in the go mod file instead of installing ginkgo out of band.

Note!!
This fix depends on the following PR to upgrade hwc to ginkgo v2 to have been merged before it works!!
PR Commit: https://github.com/cloudfoundry/hwc/pull/34/commits/e39be7bc2bddbf6a941a4992d808260db48b776a

Fixes:
```
flag provided but not defined: -u
usage: go install [build flags] [packages]
Run 'go help install' for details.
go: downloading github.com/onsi/gomega v1.27.8
...
go: added gopkg.in/yaml.v3 v3.0.1

Ginkgo detected a version mismatch between the Ginkgo CLI and the version of Ginkgo imported by your packages:
  Ginkgo CLI Version:
    2.9.5
  Mismatched package versions found:
    2.9.7 used by hwc, contextpath, hwcconfig, validator
```